### PR TITLE
Fix code scanning alert no. 16: Database query built from user-controlled sources

### DIFF
--- a/backend/database/models/userInfo.js
+++ b/backend/database/models/userInfo.js
@@ -20,7 +20,7 @@ export async function findAll() {
 } 
 export async function getUserByName(userName) {
     const user = await users.findOne({
-        userName,
+        userName: { $eq: userName },
     })
     if (!user) return null
     return user;


### PR DESCRIPTION
Fixes [https://github.com/birongliu/PetPals/security/code-scanning/16](https://github.com/birongliu/PetPals/security/code-scanning/16)

To fix the problem, we need to ensure that the `userName` parameter is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator to explicitly specify that the value should be treated as a literal. This change will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
